### PR TITLE
Allow DictReader to accept a list of lines of input.

### DIFF
--- a/csv342.py
+++ b/csv342.py
@@ -127,6 +127,8 @@ if IS_PYTHON2:
         Iterator that reads a text stream and reencodes the input to UTF-8.
         """
         def __init__(self, text_stream):
+            if isinstance(text_stream, StringIO.StringIO):
+                raise Error('Cannot read from StringIO.StringIO instances.')
             self._text_stream = text_stream
 
         def __iter__(self):

--- a/csv342.py
+++ b/csv342.py
@@ -129,7 +129,7 @@ if IS_PYTHON2:
         def __init__(self, text_stream):
             if isinstance(text_stream, StringIO.StringIO):
                 raise Error('Cannot read from StringIO.StringIO instances.')
-            self._text_stream = text_stream
+            self._text_stream = iter(text_stream)
 
         def __iter__(self):
             return self
@@ -186,9 +186,6 @@ if IS_PYTHON2:
     class DictReader:
         def __init__(self, input_stream, fieldnames=None, restkey=None, restval=None,
                      dialect="excel", *args, **kwds):
-            if isinstance(input_stream, list):
-                # DictReader can accept a list of lines of input.
-                input_stream = io.StringIO('\n'.join(input_stream))
             self._fieldnames = fieldnames
             self.restkey = restkey
             self.restval = restval

--- a/csv342.py
+++ b/csv342.py
@@ -184,6 +184,9 @@ if IS_PYTHON2:
     class DictReader:
         def __init__(self, input_stream, fieldnames=None, restkey=None, restval=None,
                      dialect="excel", *args, **kwds):
+            if isinstance(input_stream, list):
+                # DictReader can accept a list of lines of input.
+                input_stream = io.StringIO('\n'.join(input_stream))
             self._fieldnames = fieldnames
             self.restkey = restkey
             self.restval = restval

--- a/test/test_csv342.py
+++ b/test/test_csv342.py
@@ -95,8 +95,8 @@ class ReaderTest(_CsvTest):
     def test_fails_on_obsolete_StringIO(self):
         if csv.IS_PYTHON2:
             import StringIO
-            with StringIO.StringIO('a') as csv_stream:
-                self.assertRaises(csv.Error, csv.reader, csv_stream)
+            csv_stream = StringIO.StringIO('a')
+            self.assertRaises(csv.Error, csv.reader, csv_stream)
 
 
 class ExamplesText(_CsvTest):

--- a/test/test_csv342.py
+++ b/test/test_csv342.py
@@ -152,6 +152,14 @@ class DictReaderTest(unittest.TestCase):
             names_to_values = list(csv.DictReader(csv_file, delimiter=',', fieldnames=['a', 'b']))
         self.assertEqual(expected_data, names_to_values)
 
+    def test_can_read_lines_of_input(self):
+        lines_to_read = 'a,b\n1,2'.splitlines()
+        expected_data = [
+            {'a': '1', 'b': '2'}
+        ]
+        names_to_values = list(csv.DictReader(lines_to_read, delimiter=','))
+        self.assertEqual(expected_data, names_to_values)
+
 
 class DictWriterTest(_CsvTest):
     def test_can_write(self):


### PR DESCRIPTION
# Changes
Fixes #1, wherein `csv.DictReader` can read from a list of lines, but `csv342.DictReader` cannot. The fix here was to construct an `io.StringIO` instance containing the equivalent CSV text.

I also fixed an unrelated test failure, where the test asserted that StringIO.StringIO instances would not be accepted. This was failing for two reasons:
1. `StringIO` was being used as a context manager, which is not supported. This led to an `AttributeError`.
2. The code actually did accept `StringIO.StringIO` instances, which is problematic from the perspective of 2/3 compatibility. `StringIO.StringIO` switches types depending on what data is put into it, and so cannot provide an equivalent interface to Python 3. It also makes sense to force users of this library to only use the python-3-compatible `io.StringIO` buffer.

# Testing

I added a test case reproducing the failure described in #1, and verified that it fails. It passes after 6f4e79cfa081136e5308229df0232cef18f7fd5d. I also verified that the whole test suite now passes on Python 2.

# Thanks!

This library looks to be a great way of managing the upgrade to Python 3. Inconsistencies of the CSV packages between the two versions had made writing compatible code very difficult in an application I'm working on, so `csv342` is a great fit. Thanks for writing this library!