### PR TITLE
Update license in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     author="Thomas Aglassinger",
     author_email="roskakori@users.sourceforge.net",
     url="http://pypi.python.org/pypi/csv342/",
-    license="GNU Lesser General Public License 3 or later",
+    license="BSD-3-Clause",
     long_description=readme_text,
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Hey! This change updates the `license` field in `setup.py` to be consistent with what is in the license file and on pypi.

Some third party tools check the `license` field in `setup.py`, which is how I discovered this. 